### PR TITLE
fix: lowercase localpart before processing

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -47,7 +47,7 @@ func Run(args []string) int {
 		return 2
 	}
 
-	localpart := flags.Arg(0)
+	localpart := strings.ToLower(flags.Arg(0))
 	domain := flags.Arg(1)
 	owner := strings.Split(localpart, "-")[0]
 	if owner == "" || localpart == "" || domain == "" {

--- a/app/app_test.go
+++ b/app/app_test.go
@@ -5,6 +5,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/wavemechanics/qdeliver/app"
@@ -157,6 +158,7 @@ func TestInstructions(t *testing.T) {
 		{owner + `-111`, `sh -c "exit 111"`, 111},
 		{owner + `-0`, `sh -c "exit 0"`, 0},
 		{owner + `-sleep`, `sh -c "sleep 15"`, 1},
+		{owner + `-EXT`, `sh -c "exit 0"`, 0}, // this tests that webdav file matches are lower case
 	}
 
 	dir, err := ioutil.TempDir("", "TestInstructions")
@@ -194,9 +196,10 @@ func TestInstructions(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	// create the instruction file with a lower case name
 	for _, test := range tests {
 		if test.instructions != "" {
-			err = ioutil.WriteFile(filepath.Join(dir, test.address)+".txt", []byte(test.instructions), 0644)
+			err = ioutil.WriteFile(filepath.Join(dir, strings.ToLower(test.address))+".txt", []byte(test.instructions), 0644)
 			if err != nil {
 				t.Errorf("%s: can't create delivery instructions", test.address)
 				continue
@@ -222,11 +225,13 @@ func TestInstructions(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	// The address extension ("-MISSING") is upper case so we can also verify
+	// file created in the webdav area is lower case.
 	args := []string{
 		"--db", dbpath,
 		"--handler", "testdata/handler.sh",
 		"--notify", "testdata/notify.sh",
-		owner + "-missing", domain,
+		owner + "-MISSING", domain,
 	}
 
 	os.Setenv("TESTDIR", dir) // for notify.sh

--- a/man/qdeliver.man
+++ b/man/qdeliver.man
@@ -24,6 +24,9 @@ The first "-" delimited token in \fIlocalpart\fP is used as the owner in \fIuser
 If there is a file named \fIlocalpart\fP.txt in the webdav directory named in \fIuserdb\fP, then it is downloaded and used as the list of instructions.
 If there is no matching file, but there is a file named \fBdefault\fP.txt, then \fBdefault\fP.txt is copied to \fIlocalpart\fP.txt and its instructions are followed.
 
+\fIlocalpart\fP is lower-cased before any processing so files created in the webdav area are always lower case, and address matches are always lower case.
+This prevents problems created by senders who do not bother to read the RFCs.
+
 .SS userdb
 The \fIuserdb\fP file holds webdav login details for \fIowner\fP-\fIdomain\fP combinations.
 It is a JSON file that looks like this:


### PR DESCRIPTION
Make sure localpart is lower case before matching or creating webdav filenames.